### PR TITLE
[WIP] Create a docker image with PHP7 support

### DIFF
--- a/php7-mongo-replicaset/Dockerfile
+++ b/php7-mongo-replicaset/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:7.0-cli
+
+ADD php/php.ini /usr/local/etc/php/php.ini
+
+# Add 10gen official apt source to the sources list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+RUN echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+# Install MongoDB and dependencies for intl and zip extensions
+RUN apt-get update && apt-get upgrade -y && apt-get install -y mongodb-org libicu-dev g++ sudo zlib1g-dev git libssl-dev
+
+RUN echo "y\ny" | pecl install apcu-beta
+ADD php/apcu.ini /usr/local/etc/php/conf.d/apcu.ini
+RUN docker-php-ext-install bcmath mbstring opcache intl pcntl zip
+ADD php/opcache.ini /usr/local/etc/php/conf.d/ext-opcache.ini
+RUN pecl install mongo-1.6.10
+ADD php/mongo.ini /usr/local/etc/php/conf.d/mongo.ini
+
+# install composer
+RUN cd /usr/local/bin/ && curl -sS https://getcomposer.org/installer | php
+
+# Compact docker
+RUN apt-get clean -y  && rm -rf /tmp/pear/*
+
+ADD sudo/sudoers /etc/sudoers
+
+CMD /usr/bin/mongod --smallfiles --dbpath /var/lib/mongodb/ --replSet rs1 --logpath /var/log/mongodb/mongodb.log --fork && \
+    /usr/bin/mongo --eval 'rs.initiate();' && \
+    /data/bin/phpunit -c /data/app/

--- a/php7-mongo-replicaset/README.md
+++ b/php7-mongo-replicaset/README.md
@@ -1,0 +1,24 @@
+php-mongo-replicaset
+====================
+
+This docker container can be used to execute unit tests with a mongodb database (configure with a replicaset).
+
+By default, command starts mongodb and run phpunit with configuration file into /data/app directory.
+It is not very elegant because mongo and php are started in the same container but it is easier.
+
+To build the container
+----------------------
+
+```
+$ docker build -t artegeie/php7-mongo-replicaset .
+```
+
+To run the container
+--------------------
+
+Container must be run with privileged mode (due to mongodb) :
+
+```
+$ cd my-symfony2-project/
+$ docker run -it --privileged=true --rm -v `pwd`:/data -w /data artegeie/php-mongo-replicaset
+```

--- a/php7-mongo-replicaset/php/apcu.ini
+++ b/php7-mongo-replicaset/php/apcu.ini
@@ -1,0 +1,1 @@
+extension=apcu.so

--- a/php7-mongo-replicaset/php/intl.ini
+++ b/php7-mongo-replicaset/php/intl.ini
@@ -1,0 +1,1 @@
+extension=intl.so

--- a/php7-mongo-replicaset/php/mongo.ini
+++ b/php7-mongo-replicaset/php/mongo.ini
@@ -1,0 +1,36 @@
+; Enable Mongo extension module
+extension=mongo.so
+
+;  option documentation: http://www.php.net/manual/en/mongo.configuration.php
+
+;  If empty strings ("") should be allowed as key names.
+;mongo.allow_empty_keys = 0
+
+;  The number of bytes-per-chunk.
+;  This number must be at least 100 less than 4 megabytes (max: 4194204)
+;mongo.chunk_size = 261120
+
+;  A character to be used in place of $ in modifiers and comparisons.
+;mongo.cmd = $
+
+;  Default hostname when nothing is passed to the constructor.
+;mongo.default_host = localhost
+
+;  The default TCP port number. The database's default is 27017.
+;mongo.default_port = 27017
+
+;  For replicaset connections: The minimum interval with which the driver
+;  will send "isMaster" requests to the MongoDB server.
+;mongo.is_master_interval = 15
+
+;  Return a BSON_LONG as an instance of MongoInt64
+;  (instead of a primitive type).
+;mongo.long_as_object = 0
+
+;  Use MongoDB native long (this will default to true for 2.0.0)
+;  Only allowed on 64bits system
+mongo.native_long = true
+
+;  For replicaset connections: The minimum interval with which the driver
+;  will send "ping" requests to the MongoDB server.
+;mongo.ping_interval = 5

--- a/php7-mongo-replicaset/php/opcache.ini
+++ b/php7-mongo-replicaset/php/opcache.ini
@@ -1,0 +1,1 @@
+zend_extension=opcache.so

--- a/php7-mongo-replicaset/php/php.ini
+++ b/php7-mongo-replicaset/php/php.ini
@@ -1,0 +1,4 @@
+memory_limit=1024M
+
+[Date]
+date.timezone = "Europe/Paris"

--- a/php7-mongo-replicaset/sudo/sudoers
+++ b/php7-mongo-replicaset/sudo/sudoers
@@ -1,0 +1,28 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults        env_reset
+Defaults        mail_badpass
+Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Defaults        env_keep+=SSH_AUTH_SOCK
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root    ALL=(ALL:ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo   ALL=(ALL:ALL) ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d


### PR DESCRIPTION
First try to create a docker image with PHP7 support.

Unfortunately mongo driver is currently not support.